### PR TITLE
Configure the sub bg0 offset for console

### DIFF
--- a/src/display/console.rs
+++ b/src/display/console.rs
@@ -45,8 +45,8 @@ pub fn init_default() {
         .with_tilemap_base(4) // 8K offset
         .with_screen_size(0));
 
-    unsafe { core::ptr::write_volatile(mmio::BG0XOFS_MAIN as *mut u16, 0); }
-    unsafe { core::ptr::write_volatile(mmio::BG0YOFS_MAIN as *mut u16, 0); }
+    unsafe { core::ptr::write_volatile(mmio::BG0XOFS_SUB as *mut u16, 0); }
+    unsafe { core::ptr::write_volatile(mmio::BG0YOFS_SUB as *mut u16, 0); }
 
     unsafe {
         // fill tilemap with space characters


### PR DESCRIPTION
This is a cool project!

I spotted and fixed this small issue with the console, it uses sub engine bg0 but was configuring the main engine offsets, assume this was just a typo.